### PR TITLE
Use Ubuntu 19.10

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:19.10
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
At least `Objective-C` doesn't build on Ubuntu 20.10, so `./src/wrap_in_docker.sh ninja` fails.

But even on 19.10, it won't run properly, because the Elixir build fails:

```
==> jsonpath
Compiling 1 file (.ex)
Generated jsonpath app
Generated escript jsonpath with MIX_ENV=dev
/json-path-comparison
[26/10145] cd implementations/Golang_github.com-vmware-labs-yaml-jsonpath && go build -o build/main
go: finding github.com/vmware-labs/yaml-jsonpath v0.0.0-20200625154356-ea62dcd51756
go: finding github.com/icza/dyno v0.0.0-20200205103839-49cb13720835
go: finding github.com/stretchr/testify v1.5.1
go: finding gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
go: finding github.com/pmezard/go-difflib v1.0.0
go: finding github.com/stretchr/objx v0.1.0
go: finding github.com/davecgh/go-spew v1.1.0
go: finding gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
go: finding github.com/dprotaso/go-yit v0.0.0-20191028211022-135eb7262960
go: finding github.com/sergi/go-diff v1.1.0
go: finding gopkg.in/yaml.v2 v2.2.2
go: finding gopkg.in/yaml.v3 v3.0.0-20191026110619-0b21df46bc1d
go: finding github.com/onsi/gomega v1.7.0
go: finding github.com/onsi/ginkgo v1.10.2
go: finding github.com/davecgh/go-spew v1.1.1
go: finding github.com/stretchr/testify v1.4.0
go: finding github.com/kr/pretty v0.1.0
go: finding gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
go: finding gopkg.in/yaml.v2 v2.2.4
go: finding gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
go: finding gopkg.in/yaml.v2 v2.2.1
go: finding gopkg.in/fsnotify.v1 v1.4.7
go: finding golang.org/x/text v0.3.0
go: finding golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e
go: finding github.com/onsi/ginkgo v1.6.0
go: finding github.com/kr/text v0.1.0
go: finding github.com/fsnotify/fsnotify v1.4.7
go: finding github.com/hpcloud/tail v1.0.0
go: finding gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
go: finding github.com/golang/protobuf v1.2.0
go: finding golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
go: finding golang.org/x/net v0.0.0-20180906233101-161cd47e91fd
go: finding github.com/kr/pty v1.1.1
go: downloading gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
go: downloading github.com/vmware-labs/yaml-jsonpath v0.0.0-20200625154356-ea62dcd51756
go: extracting gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
go: extracting github.com/vmware-labs/yaml-jsonpath v0.0.0-20200625154356-ea62dcd51756
go: downloading github.com/dprotaso/go-yit v0.0.0-20191028211022-135eb7262960
go: extracting github.com/dprotaso/go-yit v0.0.0-20191028211022-135eb7262960
[27/10145] (cd implementations/Java_com.github.jsurfer && MAVEN_OPTS="-Dmaven.repo.local=./build/deps" mvn clean package -q) && mv implementations/Java_com.github.jsurfer/target/query-1.0-SNAPSHOT.jar implementations/Java_com.github.jsurfer/build/json-path-comparison.jar && rm -r implementations/Java_com.github.jsurfer/target
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.inject.internal.cglib.core.$ReflectUtils$1 (file:/usr/share/maven/lib/guice.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of com.google.inject.internal.cglib.core.$ReflectUtils$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
ninja: build stopped: subcommand failed.
```

But switching back from Ubuntu 20.10 to 19.10 allows to successfully build all required containers, which is better than nothing :)