### PR TITLE
Haskell: Upgrade to jsonpath-0.3.0.0

### DIFF
--- a/implementations/Haskell_jsonpath/cabal.project
+++ b/implementations/Haskell_jsonpath/cabal.project
@@ -1,0 +1,1 @@
+packages: ./json-path-comparison.cabal

--- a/implementations/Haskell_jsonpath/json-path-comparison.cabal
+++ b/implementations/Haskell_jsonpath/json-path-comparison.cabal
@@ -7,7 +7,7 @@ bug-reports:    https://github.com/cburgmer/json-path-comparison/issues
 author:         Akshay Mankar
 maintainer:     itsakshaymankar@gmail.com
 copyright:      Akshay Mankar
-license:        GPLv3
+license:        GPL-3.0
 build-type:     Simple
 
 source-repository head
@@ -20,10 +20,10 @@ executable json-path-comparison
       app
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      aeson >=1.1 && <2
-    , attoparsec
+      aeson >=2
+    , megaparsec
     , base >=4.7 && <5
     , bytestring
-    , jsonpath
+    , jsonpath >= 0.3
     , text
   default-language: Haskell2010


### PR DESCRIPTION
The implementation no longer returns the single possible match as scalar.