### PR TITLE
Give environment file to docker command

### DIFF
--- a/src/with_docker.sh
+++ b/src/with_docker.sh
@@ -6,4 +6,4 @@ readonly target_image=json-path-comparison
 
 docker build -t "$target_image" "$script_dir"
 
-docker run --rm -v "$(pwd):/json-path-comparison" -w "/json-path-comparison" -i "$target_image" "$@"
+docker run --env-file="${script_dir}/docker_env_file.txt" --rm -v "$(pwd):/json-path-comparison" -w "/json-path-comparison" -i "$target_image" "$@"


### PR DESCRIPTION
In my region the build for `implementations/Perl_JSON-Path` did not end in an acceptable amount of time because the http://www.cpan.org site to which it connects is so far away and takes so long to download requirements.
The download command at this time seems to be able to customize the mirror site with several options. Most commonly, this seems to be accomplished by simply providing an environment variable.
The `docker run` command also had an option to pass environment variables.

In this PR, add `src/docker_env_file.txt` as a mechanism to give environment variables to `docker run`. (empty by default)

For example, in my region, I solved the problem by writing the environment variable PERL_CPANM_OPT like this:
``` text
PERL_CPANM_OPT=--mirror ftp://ftp.riken.jp/lang/CPAN/
```