### PR TITLE
Fixes #156 

### DIFF
--- a/implementations/Java_com.github.jsurfer/run.sh
+++ b/implementations/Java_com.github.jsurfer/run.sh
@@ -3,4 +3,4 @@ set -euo pipefail
 
 readonly script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-java -cp "${script_dir}/build/json-path-comparison.jar:$(cat "${script_dir}/build/cp.txt")" query.App "$@"
+java -XX:+PerfDisableSharedMem -cp "${script_dir}/build/json-path-comparison.jar:$(cat "${script_dir}/build/cp.txt")" query.App "$@"

--- a/implementations/Java_com.github.xmljacquard.ajp/run.sh
+++ b/implementations/Java_com.github.xmljacquard.ajp/run.sh
@@ -7,4 +7,4 @@ filter_absolute_path_in_warning() {
     sed 's/jar:file:[^ ]*implementations\/Java_com.github.xmljacquard.ajp\//jar:file:.\/implementations\/Java_com.github.xmljacquard.ajp\//'
 }
 
-java -cp "${script_dir}/build/json-path-comparison.jar:$(cat "${script_dir}/build/cp.txt")" query.App "$@" 2>&1 | filter_absolute_path_in_warning
+java -XX:+PerfDisableSharedMem -cp "${script_dir}/build/json-path-comparison.jar:$(cat "${script_dir}/build/cp.txt")" query.App "$@" 2>&1 | filter_absolute_path_in_warning

--- a/implementations/Java_com.jayway.jsonpath/run.sh
+++ b/implementations/Java_com.jayway.jsonpath/run.sh
@@ -3,4 +3,4 @@ set -euo pipefail
 
 readonly script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-java -cp "${script_dir}/build/json-path-comparison.jar:$(cat "${script_dir}/build/cp.txt")" query.App "$@"
+java -XX:+PerfDisableSharedMem -cp "${script_dir}/build/json-path-comparison.jar:$(cat "${script_dir}/build/cp.txt")" query.App "$@"


### PR DESCRIPTION
Add a `java` command-line option for disabling file-system mapping of the java performance statistics.
This should avoid the error: `Cannot use file /tmp/hsperfdata_root/29104 because it is locked by another process (errno = 11)`