### PR TITLE
chore: explicit parse error handling for exit(2)

### DIFF
--- a/implementations/JavaScript_swaggerexpert-jsonpath/index.js
+++ b/implementations/JavaScript_swaggerexpert-jsonpath/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { evaluate, JSONPathEvaluateError } from '@swaggerexpert/jsonpath';
+import { evaluate, JSONPathParseError } from '@swaggerexpert/jsonpath';
 
 const selector = process.argv[2];
 
@@ -23,7 +23,7 @@ stdin.on('end', function () {
         const result = evaluate(json, selector);
         stdout.write(JSON.stringify(result));
     } catch (e) {
-        if (e instanceof JSONPathEvaluateError && e.message.includes('Invalid JSONPath expression')) {
+        if (e instanceof JSONPathParseError) {
             console.error(e.message);
             process.exit(2);
         }

--- a/implementations/JavaScript_swaggerexpert-jsonpath/package-lock.json
+++ b/implementations/JavaScript_swaggerexpert-jsonpath/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@swaggerexpert/jsonpath": "^4.0.1"
+        "@swaggerexpert/jsonpath": "^4.0.2"
       }
     },
     "node_modules/@swaggerexpert/jsonpath": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@swaggerexpert/jsonpath/-/jsonpath-4.0.1.tgz",
-      "integrity": "sha512-SXyThaV2oMnF89tCim4AGe6xOvlTQDKS165DZfnUieeDqrt71N2FeZzRsvCUsEGu10XpSrSaTMijXEQLF5QmgQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@swaggerexpert/jsonpath/-/jsonpath-4.0.2.tgz",
+      "integrity": "sha512-Z3eSszwJW5HEJb3FMV+HZ9QKWL/9x1N8+3BDSCFj1lHNvv/HvAy902PDQb+nesnQmYAU9eByOKjTKdErTQCCtQ==",
       "dependencies": {
         "apg-lite": "^1.0.5"
       },

--- a/implementations/JavaScript_swaggerexpert-jsonpath/package.json
+++ b/implementations/JavaScript_swaggerexpert-jsonpath/package.json
@@ -10,6 +10,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@swaggerexpert/jsonpath": "^4.0.1"
+    "@swaggerexpert/jsonpath": "^4.0.2"
   }
 }


### PR DESCRIPTION
Change was made in swaggerexpert/jsonpath to always throw parse error when invalid or not well-formed expressions is used.